### PR TITLE
Add missing key for score colour.

### DIFF
--- a/Pong/code/settings.py
+++ b/Pong/code/settings.py
@@ -1,7 +1,4 @@
-import pygame
-from os.path import join
-
-WINDOW_WIDTH, WINDOW_HEIGHT = 1280, 720 
+WINDOW_WIDTH, WINDOW_HEIGHT = 1280, 720
 SIZE = {'paddle': (40,100), 'ball': (30,30)}
 POS = {'player': (WINDOW_WIDTH - 50, WINDOW_HEIGHT / 2), 'opponent': (50, WINDOW_HEIGHT / 2)}
 SPEED = {'player': 500, 'opponent': 250, 'ball': 450}
@@ -10,5 +7,6 @@ COLORS = {
     'paddle shadow': '#b12521',
     'ball': '#ee622c',
     'ball shadow': '#c14f24',
-    'bg': '#002633'
+    'bg': '#002633',
+    'bg detail': '#004a63'
 }


### PR DESCRIPTION
Fix missing `bg detail` color key for the pong game's `settings.py`

Reference - https://www.youtube.com/watch?v=8OMghdHP-zs&t=22757s